### PR TITLE
Use spring-cloud-starter-parent

### DIFF
--- a/microservice-consul-demo/pom.xml
+++ b/microservice-consul-demo/pom.xml
@@ -1,14 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.4.3.RELEASE</version>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-starter-parent</artifactId>
+		<version>Camden.SR4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
-	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ewolff</groupId>
 	<artifactId>microservice-consul-demo</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
@@ -23,20 +24,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Camden.SR4</spring-cloud.version>
 	</properties>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
This makes sure that always the right Spring Boot version is used.

According to http://projects.spring.io/spring-cloud/#release-trains Camden.SR4 uses Spring Boot 1.4.2.RELEASE. Using the `spring-cloud-starter-parent` ensures that the right version is always used.